### PR TITLE
fix(CI): clean up mpi4py index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ test-command = "lmp -h && python {project}/tests/test_import.py"
 [tool.cibuildwheel.linux]
 before-all = [
     "yum install -y wget libpng12-devel zlib-devel libjpeg-devel",
-    '''/opt/python/cp38-cp38/bin/python -m pip install -i https://pypi.anaconda.org/mpi4py/simple mpich''',
+    '''/opt/python/cp38-cp38/bin/python -m pip install mpich''',
 ]
 [tool.cibuildwheel.linux.environment]
 CMAKE_PREFIX_PATH="/opt/python/cp38-cp38/"
@@ -62,7 +62,7 @@ CMAKE_PREFIX_PATH="/opt/python/cp38-cp38/"
 [tool.cibuildwheel.macos]
 
 before-all = [
-    '''pip install -i https://pypi.anaconda.org/mpi4py/simple mpich''',
+    '''pip install mpich''',
 ]
 environment.MACOSX_DEPLOYMENT_TARGET = "11.0"
 


### PR DESCRIPTION
It has been moved to pypi per https://github.com/mpi4py/mpi4py/releases/tag/4.1.0