### PR TITLE
CI: Replace the macos-13 images with the macos-15-intel images

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -25,7 +25,7 @@ jobs:
             python: 311
             platform_id: manylinux_aarch64
           # macos-x86-64
-          - os: macos-13
+          - os: macos-15-intel
             python: 311
             platform_id: macosx_x86_64
           # macos-arm64


### PR DESCRIPTION
per https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/